### PR TITLE
iOS下载地址转义&设置服务器访问地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Options:
 -h, --help                output usage information
 -V, --version             output the version number
 -p, --port <port-number>  set port for server (defaults is 1234)
+-h, --host <host>     set host for server (defaults is your LAN ip)
 ```
 
 ## 开启服务

--- a/ipapk-server.js
+++ b/ipapk-server.js
@@ -219,9 +219,10 @@ function main() {
           if (error) {
             errorHandler(error,res)
           }
+          console.log(info)
+          res.send(info)
         })
-        console.log(info)
-        res.send(info)
+
       }, error => {
         errorHandler(error,res)
       });

--- a/ipapk-server.js
+++ b/ipapk-server.js
@@ -31,7 +31,20 @@ String.prototype.format= function(){
   });
 }
 
-var ipAddress = underscore
+before(program, 'outputHelp', function() {
+  this.allowUnknownOption();
+});
+
+program
+    .version(version)
+    .usage('[option] [dir]')
+    .option('-p, --port <port-number>', 'set port for server (defaults is 1234)')
+    .option('-h, --host <host>', 'set host for server (defaults is your LAN ip)')
+    .parse(process.argv);
+
+var port = program.port || 1234;
+
+var ipAddress = program.host || underscore
   .chain(require('os').networkInterfaces())
   .values()
   .flatten()
@@ -40,6 +53,7 @@ var ipAddress = underscore
   })
   .value()
   .address;
+
 var pageCount = 5;
 var serverDir = os.homedir() + "/.ipapk-server/"
 var globalCerFolder = serverDir + ipAddress;
@@ -90,18 +104,6 @@ excuteDB("CREATE TABLE IF NOT EXISTS info (\
 process.exit = exit
 
 // CLI
-
-before(program, 'outputHelp', function() {
-  this.allowUnknownOption();
-});
-
-program
-  .version(version)
-  .usage('[option] [dir]')
-  .option('-p, --port <port-number>', 'set port for server (defaults is 1234)')
-  .parse(process.argv);
-
-var port = program.port || 1234;
 var basePath = "https://{0}:{1}".format(ipAddress, port);
 if (!exit.exited) {
   main();

--- a/ipapk-server.js
+++ b/ipapk-server.js
@@ -335,7 +335,18 @@ function parseText(text) {
 function extractApkIcon(filename,guid) {
   return new Promise(function(resolve,reject){
     apkParser3(filename, function (err, data) {
-      var iconPath = data["application-icon-640"]
+      var iconPath = false;
+      [640,320,240,160].every(i=>{
+        if(typeof data["application-icon-"+i] !== 'undefined'){
+          iconPath=data["application-icon-"+i];
+          return false;
+        }
+        return true;
+      });
+      if(!iconPath){
+        reject("can not find icon ");
+      }
+
       iconPath = iconPath.replace(/'/g,"")
       var tmpOut = iconsDir + "/{0}.png".format(guid)
       var zip = new AdmZip(filename); 

--- a/templates/template.plist
+++ b/templates/template.plist
@@ -11,7 +11,7 @@
 					<key>kind</key>
 					<string>software-package</string>
 					<key>url</key>
-          <string>{{basePath}}/ipa/{{guid}}.ipa</string>
+          <string>{{{basePath}}}/ipa/{{guid}}.ipa</string>
 				</dict>
 			</array>
 			<key>metadata</key>


### PR DESCRIPTION
解决我在实际使用中遇到的两个问题：
1.  iOS下载的时候，模板引擎的将`basePath`进行了转义，导致下载地址错误。
2. 默认使用的地址是局域网IP，如果是公网访问会导致图片的地址错误等。