### PR TITLE
 使用淘宝npm的sqlite3镜像，避免安装过程中源码编译（Ubuntu下无法使用镜像）

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 ```
 $ npm install -g ipapk-server
 ```
+
+国内可能无法访问S3，使用淘宝镜像下载预编译的sqlite3
+```
+$ SQLITE3_BINARY_SITE=http://npm.taobao.org/mirrors/sqlite3 npm install -g ipapk-server
+```
+
 Ubuntu 64 bit 需要另外安装
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 $ npm install -g ipapk-server
 ```
 
-国内可能无法访问S3，使用淘宝镜像下载预编译的sqlite3
+国内可能无法访问S3，使用淘宝镜像下载预编译的sqlite3（Ubuntu下镜像无效）
 ```
 $ npm install -g ipapk-server --node_sqlite3_binary_host_mirror=https://npm.taobao.org/mirrors
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install -g ipapk-server
 
 国内可能无法访问S3，使用淘宝镜像下载预编译的sqlite3
 ```
-$ SQLITE3_BINARY_SITE=http://npm.taobao.org/mirrors/sqlite3 npm install -g ipapk-server
+$ npm install -g ipapk-server --node_sqlite3_binary_host_mirror=https://npm.taobao.org/mirrors
 ```
 
 Ubuntu 64 bit 需要另外安装


### PR DESCRIPTION
由于安装过程中会下载sqlite3默认访问的是`s3.amazonaws.com`（国内要梯子）导致无法获取预编译好的二进制文件，因此使用源码编译